### PR TITLE
Added "Hold to Swing" Setting to Allow Swinging Only When Item is Off…

### DIFF
--- a/src/main/java/xyz/telosaddon/yuno/TelosAddon.java
+++ b/src/main/java/xyz/telosaddon/yuno/TelosAddon.java
@@ -68,8 +68,12 @@ public class TelosAddon implements ClientModInitializer  {
         ClientPlayerEntity player = mc.player;
         if(player == null) return;
 
-        if(mc.options.attackKey.isPressed() && config.getBoolean("SwingSetting"))
-            player.swingHand(Hand.MAIN_HAND);
+        if(mc.options.attackKey.isPressed() && config.getBoolean("SwingSetting")) {
+            boolean canSwing = !player.getItemCooldownManager().isCoolingDown(player.getMainHandStack().getItem());
+            if (!config.getBoolean("SwingIfNoCooldown") || canSwing) {
+                player.swingHand(Hand.MAIN_HAND);
+            }
+        }
 
         this.showMainRangeFeature.tick();
         this.showOffHandFeature.tick();

--- a/src/main/java/xyz/telosaddon/yuno/ui/tabs/HomeTab.java
+++ b/src/main/java/xyz/telosaddon/yuno/ui/tabs/HomeTab.java
@@ -24,6 +24,7 @@ public class HomeTab extends AbstractTab{
 
     public void loadButtons() {
         boolean swingSetting = getConfig().getBoolean("SwingSetting");
+        boolean swingIfNoCooldown = getConfig().getBoolean("SwingIfNoCooldown");
         boolean gammaSetting = getConfig().getBoolean("GammaSetting");
         boolean fpsSetting = getConfig().getBoolean("FPSSetting");
         boolean pingSetting = getConfig().getBoolean("PingSetting");
@@ -41,6 +42,10 @@ public class HomeTab extends AbstractTab{
                 new CustomButton(8, 83, 150, 20, "Hold To Swing", (button, toggled) -> {
                     toggle("SwingSetting", button.getText(), toggled);
                 }).setToggled(swingSetting),
+
+                new CustomButton(160, 83, 150, 20, "Swing Only If No Cooldown", (button, toggled) -> {
+                    toggle("SwingIfNoCooldown", button.getText(), toggled);
+                }).setToggled(swingIfNoCooldown),
 
                 new CustomButton(8, 106, 150, 20, "Gamma", (button, toggled) -> {
                     toggle("GammaSetting", button.getText(), toggled);

--- a/src/main/java/xyz/telosaddon/yuno/utils/Config.java
+++ b/src/main/java/xyz/telosaddon/yuno/utils/Config.java
@@ -101,6 +101,7 @@ public class Config {
         addDefault("LifetimeSetting", false);
 
         addDefault("SwingSetting", false);
+        addDefault("SwingIfNoCooldown", false);
         addDefault("GammaSetting", false);
         addDefault("FPSSetting", false);
         addDefault("PingSetting", false);


### PR DESCRIPTION
… Cooldown

The setting button is behind another discord RC button because I don'tknow where to put it. I tested it in singleplayer using an enderpearl.
Also the "import static xyz.telosaddon.yuno.utils.TabListUtils.stripAllFormatting;" says its not public. And at last: I couldn't put the built mod using shadow jar into my modpack that I use for Telos because it crashes, I'll send my crashlog to pixelizedGaming on dc.